### PR TITLE
Printers settings has been added as parameters

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -25,6 +25,13 @@ export interface PrintFormattedText extends PrinterToUse {
     text: string;
     mmFeedPaper?: number;
     dotsFeedPaper?: number;
+    printerDpi?: number;
+    printerWidthMM?: number;
+    printerNbrCharactersPerLine?: number;
+    charsetEncoding?: {
+        charsetName: string,
+        charsetId: number
+    };
 }
 
 export interface BitmapToHexadecimalString extends PrinterToUse {


### PR DESCRIPTION
Example of use

```typescript
ThermalPrinter.printFormattedTextAndCut({
          type: printerToUse.type,
          id: printerToUse.id,
          text: strText,
          mmFeedPaper: 120,
          printerWidthMM: 68,
          printerNbrCharactersPerLine: 48,
          charsetEncoding: {
            charsetName: 'IBM860',
            charsetId: 3
          }
},
...
```