### PR TITLE
Android M Bluetooth Permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,30 +25,15 @@ Don't forget to add BLUETOOTH and INTERNET (for TCP) permissions and for USB pri
 ```xml
 <uses-feature android:name="android.hardware.usb.host" />
 <uses-permission android:name="android.permission.BLUETOOTH" />
-<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 ```
 
-In `capacitor.config.json`
-```ts
-"android": {
-    "permissions": [
-    {
-        "name": "BLUETOOTH",
-        "description": "Needed for Bluetooth communication"
-    },
-    {
-        "name": "BLUETOOTH_CONNECT",
-        "description": "Needed for Bluetooth communication"
-    },
-    {
-        "name": "BLUETOOTH_SCAN",
-        "description": "Needed for Bluetooth communication"
-    },
-    {
-        "name": "BLUETOOTH_ADMIN",
-        "description": "Needed for Bluetooth communication"
-    }
-]
+Run this for getting Bluetooth access permission if needed
+
+```javascript
+ThermalPrinter.requestBTPermissions({type: 'bluetooth'}, function(result){ console.log(result) }, function(error){ console.log(error) });
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Request permissions for USB printers
 <a name="requestBTPermissions"></a>
 
 ### requestBTPermissions(data, successCallback, errorCallback)
-Request permissions for Bluetooth
+Request permissions for bluetooth
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Don't forget to add BLUETOOTH and INTERNET (for TCP) permissions and for USB pri
 
 ```xml
 <uses-feature android:name="android.hardware.usb.host" />
-<uses-permission android:name="android.permission.BLUETOOTH" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+<uses-permission android:maxSdkVersion="30" android:name="android.permission.BLUETOOTH" />
+<uses-permission android:maxSdkVersion="30" android:name="android.permission.BLUETOOTH_ADMIN" />
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 ```

--- a/README.md
+++ b/README.md
@@ -223,6 +223,19 @@ Request permissions for USB printers
 | successCallback | <code>function</code> | Result on success |
 | errorCallback | <code>function</code> | Result on failure |
 
+
+<a name="requestBTPermissions"></a>
+
+### requestBTPermissions(data, successCallback, errorCallback)
+Request permissions for Bluetooth
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>Array.&lt;Object&gt;</code> | Data object |
+| data.type | <code>&quot;bluetooth&quot;</code> | List all bluetooth or usb printers |
+| successCallback | <code>function</code> | Result on success |
+| errorCallback | <code>function</code> | Result on failure |
+
 <a name="bitmapToHexadecimalString"></a>
 
 ### bitmapToHexadecimalString(data, successCallback, errorCallback)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ Don't forget to add BLUETOOTH and INTERNET (for TCP) permissions and for USB pri
 <uses-permission android:name="android.permission.INTERNET" />
 ```
 
+In `capacitor.config.json`
+```ts
+"android": {
+    "permissions": [
+    {
+        "name": "BLUETOOTH",
+        "description": "Needed for Bluetooth communication"
+    },
+    {
+        "name": "BLUETOOTH_CONNECT",
+        "description": "Needed for Bluetooth communication"
+    },
+    {
+        "name": "BLUETOOTH_SCAN",
+        "description": "Needed for Bluetooth communication"
+    },
+    {
+        "name": "BLUETOOTH_ADMIN",
+        "description": "Needed for Bluetooth communication"
+    }
+]
+```
+
 ### Examples
 
 #### Notice for TypeScript-Developers
@@ -138,8 +161,11 @@ Print a formatted text and feed paper
 | [data.id] | <code>string</code> \| <code>number</code> | ID of printer to find (Bluetooth: address, TCP: Use address + port instead, USB: deviceId) |
 | [data.address] | <code>string</code> | If type is "tcp" then the IP Address of the printer |
 | [data.port] | <code>number</code> | If type is "tcp" then the Port of the printer |
-| [data.mmFeedPaper] | <code>number</code> | Millimeter distance feed paper at the end |
-| [data.dotsFeedPaper] | <code>number</code> | Distance feed paper at the end |
+| [data.mmFeedPaper] | <code>number</code><code>optional</code> | Millimeter distance feed paper at the end |
+| [data.dotsFeedPaper] | <code>number</code><code>optional</code> | Distance feed paper at the end |
+| [data.printerDpi] | <code>number</code><code>optional</code> | Printer DPI |
+| [data.printerWidthMM] | <code>number</code><code>optional</code> | Paper Width in mm |
+| [data.printerNbrCharactersPerLine] | <code>number</code><code>optional</code> | Number of characters per line |
 | data.text | <code>string</code> | Formatted text to be printed |
 | successCallback | <code>function</code> | Result on success |
 | errorCallback | <code>function</code> | Result on failure |
@@ -158,8 +184,11 @@ Print a formatted text, feed paper and cut the paper
 | [data.id] | <code>string</code> \| <code>number</code> | ID of printer to find (Bluetooth: address, TCP: Use address + port instead, USB: deviceId) |
 | [data.address] | <code>string</code> | If type is "tcp" then the IP Address of the printer |
 | [data.port] | <code>number</code> | If type is "tcp" then the Port of the printer |
-| [data.mmFeedPaper] | <code>number</code> | Millimeter distance feed paper at the end |
-| [data.dotsFeedPaper] | <code>number</code> | Distance feed paper at the end |
+| [data.mmFeedPaper] | <code>number</code><code>optional</code> | Millimeter distance feed paper at the end |
+| [data.dotsFeedPaper] | <code>number</code><code>optional</code> | Distance feed paper at the end |
+| [data.printerDpi] | <code>number</code><code>optional</code> | Printer DPI |
+| [data.printerWidthMM] | <code>number</code><code>optional</code> | Paper Width in mm |
+| [data.printerNbrCharactersPerLine] | <code>number</code><code>optional</code> | Number of characters per line |
 | data.text | <code>string</code> | Formatted text to be printed |
 | successCallback | <code>function</code> | Result on success |
 | errorCallback | <code>function</code> | Result on failure |
@@ -221,6 +250,10 @@ Convert Drawable instance to a hexadecimal string of the image data
 | [data.id] | <code>string</code> \| <code>number</code> | ID of printer to find (Bluetooth: address, TCP: Use address + port instead, USB: deviceId) |
 | [data.address] | <code>string</code> | If type is "tcp" then the IP Address of the printer |
 | [data.port] | <code>number</code> | If type is "tcp" then the Port of the printer |
+| [data.mmFeedPaper] | <code>number</code><code>optional</code> | Millimeter distance feed paper at the end |
+| [data.dotsFeedPaper] | <code>number</code><code>optional</code> | Distance feed paper at the end |
+| [data.printerDpi] | <code>number</code><code>optional</code> | Printer DPI |
+| [data.printerWidthMM] | <code>number</code><code>optional</code> | Paper Width in mm |
 | data.base64 | <code>string</code> | Base64 encoded picture string to convert |
 | successCallback | <code>function</code> | Result on success |
 | errorCallback | <code>function</code> | Result on failure |

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,8 +17,11 @@
 
         <config-file parent="/*" target="AndroidManifest.xml">
             <uses-feature android:name="android.hardware.usb.host" />
-            <uses-permission android:name="android.permission.BLUETOOTH" />
+            <uses-permission android:maxSdkVersion="30" android:name="android.permission.BLUETOOTH" />
             <uses-permission android:name="android.permission.INTERNET" />
+            <uses-permission android:maxSdkVersion="30" android:name="android.permission.BLUETOOTH_ADMIN" />
+            <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+            <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
         </config-file>
 
         <source-file src="src/android/ThermalPrinterCordovaPlugin.java" target-dir="src/de/paystory/thermal_printer" />

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,5 +5,5 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.2.0'
+    implementation 'com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.2.1'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,5 +5,5 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.2.1'
+    implementation 'com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.2.0'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -5,5 +5,5 @@ allprojects {
 }
 
 dependencies {
-   implementation 'com.github.DantSu:ESCPOS-ThermalPrinter-Android:2.0.8'
+    implementation 'com.github.DantSu:ESCPOS-ThermalPrinter-Android:3.2.1'
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,10 +19,6 @@ export interface PrinterToUse {
     id: string | number;
     address?: string;
     port?: number;
-}
-
-export interface PrintFormattedText extends PrinterToUse {
-    text: string;
     mmFeedPaper?: number;
     dotsFeedPaper?: number;
     printerDpi?: number;
@@ -32,6 +28,10 @@ export interface PrintFormattedText extends PrinterToUse {
         charsetName: string,
         charsetId: number
     };
+}
+
+export interface PrintFormattedText extends PrinterToUse {
+    text: string;
 }
 
 export interface BitmapToHexadecimalString extends PrinterToUse {
@@ -137,7 +137,8 @@ export interface ThermalPrinterPlugin {
 
   /**
    * Convert Drawable instance to a hexadecimal string of the image data
-   *
+   * Note: Supports only 255px height 
+   * 
    * @param {Object[]} data - Data object
    * @param {"bluetooth"|"tcp"|"usb"} data.type - List all bluetooth or usb printers
    * @param {string|number} [data.id] - ID of printer to find (Bluetooth: address, TCP: Use address + port instead, USB: deviceId)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -40,6 +40,10 @@ export interface BitmapToHexadecimalString extends PrinterToUse {
 
 export interface RequestPermissionsResult {
     granted: boolean;
+    BLUETOOTH?: boolean;
+    BLUETOOTH_ADMIN?: boolean;
+    BLUETOOTH_CONNECT?: boolean;
+    BLUETOOTH_SCAN?: boolean;
 }
 
 export interface GetEncodingResult {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -135,6 +135,19 @@ export interface ThermalPrinterPlugin {
    */
   requestPermissions(data: PrinterToUse, success: (value: RequestPermissionsResult) => any, error: (value: ErrorResult) => void);
 
+   /**
+   * Request permissions for Bluetooth
+   *
+   * @param {Object[]} data - Data object
+   * @param {"bluetooth"} data.type - List all bluetooth printers
+   * @param {string|number} [data.id] - ID of printer to find (Bluetooth: address, TCP: Use address + port instead, USB: deviceId)
+   * @param {string} [data.address] - If type is "tcp" then the IP Address of the printer
+   * @param {number} [data.port] - If type is "tcp" then the Port of the printer
+   * @param {function} success
+   * @param {function} error
+   */
+  requestBTPermissions(data: PrinterToUse, success: (value: RequestPermissionsResult) => any, error: (value: ErrorResult) => void);
+
   /**
    * Convert Drawable instance to a hexadecimal string of the image data
    * Note: Supports only 255px height 

--- a/www/thermal-printer.js
+++ b/www/thermal-printer.js
@@ -95,6 +95,22 @@ module.exports = {
   requestPermissions: function(data, successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, 'ThermalPrinter', 'requestPermissions', [data]);
   },
+  
+  
+  /**
+   * Request permissions for Bluethoot
+   *
+   * @param {Object[]} data - Data object
+   * @param {"bluetooth"} data.type - List all bluetooth or usb printers
+   * @param {string|number} [data.id] - ID of printer to find (Bluetooth: address, TCP: Use address + port instead, USB: deviceId)
+   * @param {string} [data.address] - If type is "tcp" then the IP Address of the printer
+   * @param {number} [data.port] - If type is "tcp" then the Port of the printer
+   * @param {function} successCallback - Result on success
+   * @param {function} errorCallback - Result on failure
+   */
+  requestBTPermissions: function(data, successCallback, errorCallback) {
+    cordova.exec(successCallback, errorCallback, 'ThermalPrinter', 'requestBTPermissions', [data]);
+  },
 
   /**
    * Convert Drawable instance to a hexadecimal string of the image data


### PR DESCRIPTION
I have made some changes to the Android M Bluetooth Permission handling in this pull request. Additionally, a new method for Bluetooth permission has been added.

The new method is as follows:

```javascript
ThermalPrinter.requestBTPermissions({type: 'bluetooth'}, function(result){ console.log(result) }, function(error){ console.log(error) });
```

This method enables the app to request Bluetooth permissions from the user. The type parameter specifies the type of Bluetooth permissions that are being requested.

Please review these changes and let me know if any further modifications are needed.